### PR TITLE
feat: Replace Sankey and Sunburst charts with working alternatives

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   path: ^1.9.0
   permission_handler: ^12.0.0
   syncfusion_flutter_charts: ^29.2.4
+  sankey_flutter: ^0.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Replaces the non-functional SfSankey widget with `sankey_flutter` package.
  - Adds `sankey_flutter: ^0.0.3` to `pubspec.yaml`.
  - Implements data transformation in `dashboard_screen.dart` to prepare data for `SankeyChart`.
  - Updates UI to use `SankeyChart`.

- Replaces the non-functional SfSunburstChart widget with a Doughnut chart from `syncfusion_flutter_charts`.
  - Updates `dashboard_screen.dart` to use `SfCircularChart` with `DoughnutSeries`.
  - Configures data labels, tooltips, title, and legend for the Doughnut chart.

- Ensures `_sunburstTotalExpenses` is calculated correctly with null safety.
- Corrects 'ytd' period value to 'yearToDate' for consistency with backend.